### PR TITLE
Stop relying on default()

### DIFF
--- a/examples/visualizer.rs
+++ b/examples/visualizer.rs
@@ -162,7 +162,8 @@ impl EventHandler for Visualizer {
 
 		let area = [100.0, 160.0, screen_size.0 - 100.0 * 2.0, screen_size.1 - 160.0 * 2.0];
 		let now = std::time::Instant::now();
-		let point: Point2<f32> = [area[0] + self.keyframes.now().x * area[2], area[1] + (1.0 - self.keyframes.now().y) * area[3]].into();
+		let kf_now = self.keyframes.now_strict().unwrap();
+		let point: Point2<f32> = [area[0] + kf_now.x * area[2], area[1] + (1.0 - kf_now.y) * area[3]].into();
 		self.time_in_crate += (std::time::Instant::now() - now).as_secs_f64();
 
 		let circle = Mesh::new_circle(ctx, DrawMode::Fill(FillOptions::DEFAULT), point, 4.0, 2.0, Color::new(0.83, 0.17, 0.12, 1.0))?;

--- a/src/functions/dynamic_functions.rs
+++ b/src/functions/dynamic_functions.rs
@@ -144,9 +144,9 @@ pub use bezier::*;
 pub struct Keyframes([f64; SAMPLE_TABLE_SIZE]);
 
 impl Keyframes {
-	pub(crate) fn from_easing_function<T: Float + CanTween + Copy>(mut s: AnimationSequence<T>) -> Self where Keyframe<T>: Default {
-		let mut low_point = s.sequence.get(0).unwrap_or(&Keyframe::default()).value().to_f64().unwrap_or(0.0);
-		let mut high_point = s.sequence.get(s.keyframes() - 1).unwrap_or(&Keyframe::default()).value().to_f64().unwrap_or(1.0);
+	pub(crate) fn from_easing_function<T: Float + CanTween + Copy>(mut s: AnimationSequence<T>) -> Self {
+		let mut low_point = s.sequence.get(0).and_then(|kf| kf.value().to_f64()).unwrap_or(0.0);
+		let mut high_point = s.sequence.get(s.keyframes() - 1).and_then(|kf| kf.value().to_f64()).unwrap_or(1.0);
 		let max_time = s.duration();
 
 		if high_point == 0.0 || high_point == low_point {
@@ -157,7 +157,7 @@ impl Keyframes {
 		let mut sample_table = [0.0; SAMPLE_TABLE_SIZE];
 		for i in 0..SAMPLE_TABLE_SIZE {
 			s.advance_to((i as f64 / (SAMPLE_TABLE_SIZE - 1) as f64) * max_time);
-			sample_table[i] = (s.now().to_f64().unwrap_or(0.5) - low_point) / (high_point - low_point);
+			sample_table[i] = (s.now_strict().and_then(|v| v.to_f64()).unwrap_or(0.5) - low_point) / (high_point - low_point);
 		}
 
 		Keyframes(sample_table)


### PR DESCRIPTION
Fixes #1 
cc @ nazar-pc

The one thing I'm not happy about is `fn now()`, other stuff looks good, I think.

There is a few tests failing related to the derive stuff, not caused by this change. Do you run any CI?
I also tried to `cargo fmt` but it looks like the code hasn't been formatted recently.