### PR TITLE
possibility to use the crate in no_std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "A simple library for animation in Rust"
 readme = "README.md"
 repository = "https://github.com/HannesMann/keyframe"
 license = "MIT"
-version = "1.1.4"
+version = "1.1.0"
 edition = "2018"
 
 authors = ["Hannes Mann <hannesmann2000@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["animation", "transitions", "easing", "gamedev", "graphics"]
 categories = ["mathematics", "graphics"]
 
 [dependencies]
-num-traits = "0.2.10"
+num-traits = {version = "0.2.10", default-features = false}
 mint = { version = "0.5.6", optional = true }
 
 [dev-dependencies]
@@ -21,11 +21,12 @@ ggez = "0.6.0"
 num-derive = "0.3.3"
 
 [features]
-default = ["mint_types"]
+default = ["mint_types", "alloc"]
 
 # Defines easing functions for mint's Vector2, Vector3, Vector4, Point2 and Point3
 # Also required for BezierFunction
 mint_types = ["mint"]
+alloc = []
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "docs/preview.html" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "A simple library for animation in Rust"
 readme = "README.md"
 repository = "https://github.com/HannesMann/keyframe"
 license = "MIT"
-version = "1.0.4"
+version = "1.1.4"
 edition = "2018"
 
 authors = ["Hannes Mann <hannesmann2000@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["animation", "transitions", "easing", "gamedev", "graphics"]
 categories = ["mathematics", "graphics"]
 
 [dependencies]
-num-traits = {version = "0.2.10", default-features = false}
+num-traits = {version = "0.2.10", default-features = false, features = ["libm"]}
 mint = { version = "0.5.6", optional = true }
 
 [dev-dependencies]

--- a/examples/visualizer.rs
+++ b/examples/visualizer.rs
@@ -1,31 +1,35 @@
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
-use ggez::{Context, ContextBuilder, GameResult, GameError};
+use ggez::{Context, ContextBuilder, GameError, GameResult};
 
 use ggez::conf::{WindowMode, WindowSetup};
 use ggez::event::EventHandler;
 use ggez::graphics::*;
 use ggez::mint::Point2;
 
-use keyframe::{keyframes, AnimationSequence, functions::*};
+use keyframe::{functions::*, keyframes, AnimationSequence};
 
 fn main() -> GameResult {
 	let (ctx, event_loop) = ContextBuilder::new("visualizer", "Hannes Mann")
-		.window_mode(WindowMode::default()
-			.dimensions(848.0, 480.0)
-			.min_dimensions(500.0, 340.0)
-			.resizable(true))
-		.window_setup(WindowSetup::default()
-			.title("Sequence Visualizer")
-			.samples(ggez::conf::NumSamples::Four)
-			.vsync(false))
+		.window_mode(
+			WindowMode::default()
+				.dimensions(848.0, 480.0)
+				.min_dimensions(500.0, 340.0)
+				.resizable(true),
+		)
+		.window_setup(
+			WindowSetup::default()
+				.title("Sequence Visualizer")
+				.samples(ggez::conf::NumSamples::Four)
+				.vsync(false),
+		)
 		.build()?;
 
 	let vis = Visualizer {
 		example: VisualizerExample::EaseInOutFourPoint,
 		keyframes: match_sequence(&VisualizerExample::EaseInOutFourPoint),
-		time_in_crate: 0.0
+		time_in_crate: 0.0,
 	};
 	ggez::event::run(ctx, event_loop, vis)
 }
@@ -39,12 +43,15 @@ enum VisualizerExample {
 	LinearCircle30Point,
 	BezierFourPoint,
 	KeyframesFunctionFourPoint,
-	Last
+	Last,
 }
 
 fn match_sequence(example: &VisualizerExample) -> AnimationSequence<Point2<f32>> {
 	match example {
-		VisualizerExample::LinearTwoPoint => keyframes![([0.0, 0.0].into(), 0.0, Linear), ([1.0, 1.0].into(), 1.0, Linear)],
+		VisualizerExample::LinearTwoPoint => keyframes![
+			([0.0, 0.0].into(), 0.0, Linear),
+			([1.0, 1.0].into(), 1.0, Linear)
+		],
 		VisualizerExample::LinearFourPoint => keyframes![
 			([0.0, 0.0].into(), 0.0, Linear),
 			([0.2, 0.4].into(), 0.3, Linear),
@@ -63,11 +70,18 @@ fn match_sequence(example: &VisualizerExample) -> AnimationSequence<Point2<f32>>
 			for i in 0..=30 {
 				let sin = ((i as f32 / 30.0) * std::f32::consts::PI * 2.0).sin();
 				let cos = ((i as f32 / 30.0) * std::f32::consts::PI * 2.0).cos();
-				keyframes.push(([sin * 0.5 + 0.5, cos * 0.5 + 0.5].into(), i as f64 / 30.0, Linear).into());
+				keyframes.push(
+					(
+						[sin * 0.5 + 0.5, cos * 0.5 + 0.5].into(),
+						i as f64 / 30.0,
+						Linear,
+					)
+						.into(),
+				);
 			}
 
 			AnimationSequence::from(keyframes)
-		},
+		}
 		VisualizerExample::BezierFourPoint => {
 			// https://easings.net/en#easeInCirc
 			let bezier = BezierCurve::from([0.6, 0.04].into(), [0.98, 0.335].into());
@@ -78,7 +92,7 @@ fn match_sequence(example: &VisualizerExample) -> AnimationSequence<Point2<f32>>
 				([0.8, 0.4].into(), 0.8, bezier),
 				([1.0, 1.0].into(), 1.0, bezier)
 			]
-		},
+		}
 		VisualizerExample::KeyframesFunctionFourPoint => {
 			// The easing function is normalized after creation, this is the same as specifying:
 			// (0.0, 0.0, Linear)
@@ -90,7 +104,8 @@ fn match_sequence(example: &VisualizerExample) -> AnimationSequence<Point2<f32>>
 				(-0.8, 0.4, Linear),
 				(-0.8, 0.8, Linear),
 				(-2.0, 1.0, Linear)
-			].to_easing_function();
+			]
+			.to_easing_function();
 
 			keyframes![
 				([0.0, 0.0].into(), 0.0, function),
@@ -98,15 +113,15 @@ fn match_sequence(example: &VisualizerExample) -> AnimationSequence<Point2<f32>>
 				([0.8, 0.4].into(), 0.8, function),
 				([1.0, 1.0].into(), 1.0, function)
 			]
-		},
-		_ => keyframes![]
+		}
+		_ => keyframes![],
 	}
 }
 
 struct Visualizer {
 	example: VisualizerExample,
 	keyframes: AnimationSequence<Point2<f32>>,
-	time_in_crate: f64
+	time_in_crate: f64,
 }
 
 impl EventHandler<GameError> for Visualizer {
@@ -114,7 +129,8 @@ impl EventHandler<GameError> for Visualizer {
 		self.time_in_crate = 0.0;
 
 		let now = std::time::Instant::now();
-		self.keyframes.advance_and_maybe_reverse(ggez::timer::delta(ctx).as_secs_f64() * 0.5);
+		self.keyframes
+			.advance_and_maybe_reverse(ggez::timer::delta(ctx).as_secs_f64() * 0.5);
 		self.time_in_crate += (std::time::Instant::now() - now).as_secs_f64();
 
 		Ok(())
@@ -125,27 +141,42 @@ impl EventHandler<GameError> for Visualizer {
 		clear(ctx, Color::WHITE);
 
 		let t = Text::new(TextFragment {
-			text: format!("{:?} {:.2}/{:.2} s", self.example, self.keyframes.time() * 2.0, self.keyframes.duration() * 2.0),
+			text: format!(
+				"{:?} {:.2}/{:.2} s",
+				self.example,
+				self.keyframes.time() * 2.0,
+				self.keyframes.duration() * 2.0
+			),
 			font: None,
 			scale: Some(PxScale::from(40.0)),
 			..Default::default()
 		});
 		let size = t.dimensions(ctx);
-		draw(ctx, &t, DrawParam::default()
-			.dest([(screen_size.0 / 2.0 - size.w as f32 / 2.0).round(), 20.0])
-			.color(Color::BLACK)
+		draw(
+			ctx,
+			&t,
+			DrawParam::default()
+				.dest([(screen_size.0 / 2.0 - size.w as f32 / 2.0).round(), 20.0])
+				.color(Color::BLACK),
 		)?;
 
 		let t = Text::new(TextFragment {
-			text: format!("{:?} -> {:?}", self.keyframes.pair().0, self.keyframes.pair().1),
+			text: format!(
+				"{:?} -> {:?}",
+				self.keyframes.pair().0,
+				self.keyframes.pair().1
+			),
 			font: None,
 			scale: Some(PxScale::from(15.0)),
 			..Default::default()
 		});
 		let size = t.dimensions(ctx);
-		draw(ctx, &t, DrawParam::default()
-			.dest([(screen_size.0 / 2.0 - size.w as f32 / 2.0).round(), 60.0])
-			.color(Color::BLACK)
+		draw(
+			ctx,
+			&t,
+			DrawParam::default()
+				.dest([(screen_size.0 / 2.0 - size.w as f32 / 2.0).round(), 60.0])
+				.color(Color::BLACK),
 		)?;
 
 		let t = Text::new(TextFragment {
@@ -155,23 +186,50 @@ impl EventHandler<GameError> for Visualizer {
 			..Default::default()
 		});
 		let size = t.dimensions(ctx);
-		draw(ctx, &t, DrawParam::default()
-			.dest([(screen_size.0 / 2.0 - size.w as f32 / 2.0).round(), screen_size.1 - 60.0])
-			.color(Color::BLACK)
+		draw(
+			ctx,
+			&t,
+			DrawParam::default()
+				.dest([
+					(screen_size.0 / 2.0 - size.w as f32 / 2.0).round(),
+					screen_size.1 - 60.0,
+				])
+				.color(Color::BLACK),
 		)?;
 
-		let area = [100.0, 160.0, screen_size.0 - 100.0 * 2.0, screen_size.1 - 160.0 * 2.0];
+		let area = [
+			100.0,
+			160.0,
+			screen_size.0 - 100.0 * 2.0,
+			screen_size.1 - 160.0 * 2.0,
+		];
 		let now = std::time::Instant::now();
 		let kf_now = self.keyframes.now_strict().unwrap();
-		let point: Point2<f32> = [area[0] + kf_now.x * area[2], area[1] + (1.0 - kf_now.y) * area[3]].into();
+		let point: Point2<f32> = [
+			area[0] + kf_now.x * area[2],
+			area[1] + (1.0 - kf_now.y) * area[3],
+		]
+		.into();
 		self.time_in_crate += (std::time::Instant::now() - now).as_secs_f64();
 
-		let circle = Mesh::new_circle(ctx, DrawMode::Fill(FillOptions::DEFAULT), point, 4.0, 2.0, Color::new(0.83, 0.17, 0.12, 1.0))?;
+		let circle = Mesh::new_circle(
+			ctx,
+			DrawMode::Fill(FillOptions::DEFAULT),
+			point,
+			4.0,
+			2.0,
+			Color::new(0.83, 0.17, 0.12, 1.0),
+		)?;
 		draw(ctx, &circle, DrawParam::default())?;
 
 		for k in &self.keyframes {
 			let text = Text::new(TextFragment {
-				text: format!("({:.1}, {:.1}) at {:.1} s", k.value().x, k.value().y, k.time() * 2.0),
+				text: format!(
+					"({:.1}, {:.1}) at {:.1} s",
+					k.value().x,
+					k.value().y,
+					k.time() * 2.0
+				),
 				font: None,
 				scale: Some(PxScale::from(14.0)),
 				..Default::default()
@@ -179,52 +237,77 @@ impl EventHandler<GameError> for Visualizer {
 
 			let p: Point2<f32> = [
 				(area[0] + k.value().x * area[2] - text.dimensions(ctx).w as f32 / 2.0).round(),
-				(area[1] + (1.0 - k.value().y) * area[3] - 20.0).round()
-			].into();
+				(area[1] + (1.0 - k.value().y) * area[3] - 20.0).round(),
+			]
+			.into();
 
-			draw(ctx, &text, DrawParam::default()
-				.dest(p)
-				.color(Color::new(0.83, 0.17, 0.12, 1.0))
+			draw(
+				ctx,
+				&text,
+				DrawParam::default()
+					.dest(p)
+					.color(Color::new(0.83, 0.17, 0.12, 1.0)),
 			)?;
 		}
 
 		let t = Text::new(TextFragment {
-			text: format!("FPS: {:.1} (ft: {:.2} ms, c: {:.2} ms)", ggez::timer::fps(ctx), ggez::timer::delta(ctx).as_secs_f64() * 1000.0, self.time_in_crate * 1000.0),
+			text: format!(
+				"FPS: {:.1} (ft: {:.2} ms, c: {:.2} ms)",
+				ggez::timer::fps(ctx),
+				ggez::timer::delta(ctx).as_secs_f64() * 1000.0,
+				self.time_in_crate * 1000.0
+			),
 			font: None,
 			scale: Some(PxScale::from(20.0)),
 			..Default::default()
 		});
-		draw(ctx, &t, DrawParam::default()
-			.dest([10.0, 10.0])
-			.color(Color::new(0.1, 0.9, 0.1, 1.0))
+		draw(
+			ctx,
+			&t,
+			DrawParam::default()
+				.dest([10.0, 10.0])
+				.color(Color::new(0.1, 0.9, 0.1, 1.0)),
 		)?;
 
 		present(ctx)
 	}
 
 	fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) {
-		set_screen_coordinates(ctx, [0.0, 0.0, width, height].into()).expect("Couldn't resize screen");
+		set_screen_coordinates(ctx, [0.0, 0.0, width, height].into())
+			.expect("Couldn't resize screen");
 	}
 
-	fn key_down_event(&mut self, _ctx: &mut Context, keycode: ggez::input::keyboard::KeyCode, _keymods: ggez::input::keyboard::KeyMods, _repeat: bool) {
+	fn key_down_event(
+		&mut self,
+		_ctx: &mut Context,
+		keycode: ggez::input::keyboard::KeyCode,
+		_keymods: ggez::input::keyboard::KeyMods,
+		_repeat: bool,
+	) {
 		let now = std::time::Instant::now();
 		let mut example: i32 = unsafe { std::mem::transmute(self.example.clone()) };
 
 		example += match keycode {
 			ggez::input::keyboard::KeyCode::Left => -1,
 			ggez::input::keyboard::KeyCode::Right => 1,
-			_ => 0
+			_ => 0,
 		};
 
 		if example < 0 {
-			example = unsafe { std::mem::transmute::<VisualizerExample, i32>(VisualizerExample::Last) - 1 };
-		}
-		else if example >= unsafe { std::mem::transmute::<VisualizerExample, i32>(VisualizerExample::Last) } {
+			example = unsafe {
+				std::mem::transmute::<VisualizerExample, i32>(VisualizerExample::Last) - 1
+			};
+		} else if example
+			>= unsafe { std::mem::transmute::<VisualizerExample, i32>(VisualizerExample::Last) }
+		{
 			example = 0;
 		}
 
-		if self.example != FromPrimitive::from_i32(example).unwrap_or(VisualizerExample::LinearTwoPoint) {
-			self.example = FromPrimitive::from_i32(example).unwrap_or(VisualizerExample::LinearTwoPoint);
+		if self.example
+			!= FromPrimitive::from_i32(example).unwrap_or(VisualizerExample::LinearTwoPoint)
+		{
+			self.example =
+				FromPrimitive::from_i32(example).unwrap_or(VisualizerExample::LinearTwoPoint);
 			self.keyframes = match_sequence(&self.example);
 			self.time_in_crate += (std::time::Instant::now() - now).as_secs_f64();
 		}

--- a/src/easing.rs
+++ b/src/easing.rs
@@ -66,30 +66,56 @@ impl<T: CanTween> CanTween for alloc::vec::Vec<T> {
 /// Returns the value at a specified X position on the curve between point A and point B.
 /// The time argument is expected to stay within a range of 0.0 to 1.0 but bounds checking is not enforced.
 #[inline]
-pub fn ease_with_unbounded_time<V: CanTween, F: EasingFunction>(function: impl Borrow<F>, from: V, to: V, time: impl Float) -> V {
+pub fn ease_with_unbounded_time<V: CanTween, F: EasingFunction>(
+	function: impl Borrow<F>,
+	from: V,
+	to: V,
+	time: impl Float,
+) -> V {
 	V::ease(from, to, function.borrow().y(as_f64(time)))
 }
 
 /// Returns the value at a specified X position on the curve between point A and point B.
 /// Time is limited to a range between 0.0 and 1.0.
 #[inline]
-pub fn ease<V: CanTween, T: Float, F: EasingFunction>(function: impl Borrow<F>, from: V, to: V, time: T) -> V {
-	ease_with_unbounded_time(function, from, to, match time {
-		_ if time < T::zero() => T::zero(),
-		 _ if time > T::one() => T::one(),
-		_ => time
-	})
+pub fn ease<V: CanTween, T: Float, F: EasingFunction>(
+	function: impl Borrow<F>,
+	from: V,
+	to: V,
+	time: T,
+) -> V {
+	ease_with_unbounded_time(
+		function,
+		from,
+		to,
+		match time {
+			_ if time < T::zero() => T::zero(),
+			_ if time > T::one() => T::one(),
+			_ => time,
+		},
+	)
 }
 
 /// Returns the value at a specified X position on the curve between point A and point B.
 /// Time is limited to a range between 0.0 and `max_time`.
 #[inline]
-pub fn ease_with_scaled_time<V: CanTween, T: Float, F: EasingFunction>(function: impl Borrow<F>, from: V, to: V, time: T, max_time: T) -> V {
-	ease(function, from, to, match time {
-		_ if time < T::zero() => T::zero(),
-		_ if time > max_time => T::one(),
-		_ => time / max_time
-	})
+pub fn ease_with_scaled_time<V: CanTween, T: Float, F: EasingFunction>(
+	function: impl Borrow<F>,
+	from: V,
+	to: V,
+	time: T,
+	max_time: T,
+) -> V {
+	ease(
+		function,
+		from,
+		to,
+		match time {
+			_ if time < T::zero() => T::zero(),
+			_ if time > max_time => T::one(),
+			_ => time / max_time,
+		},
+	)
 }
 
 #[cfg(feature = "mint_types")]
@@ -101,7 +127,7 @@ mod mint_type_impls {
 		fn ease(from: Self, to: Self, time: impl Float) -> Self {
 			Self {
 				x: V::ease(from.x, to.x, time),
-				y: V::ease(from.y, to.y, time)
+				y: V::ease(from.y, to.y, time),
 			}
 		}
 	}
@@ -112,7 +138,7 @@ mod mint_type_impls {
 			Self {
 				x: V::ease(from.x, to.x, time),
 				y: V::ease(from.y, to.y, time),
-				z: V::ease(from.z, to.z, time)
+				z: V::ease(from.z, to.z, time),
 			}
 		}
 	}
@@ -124,7 +150,7 @@ mod mint_type_impls {
 				x: V::ease(from.x, to.x, time),
 				y: V::ease(from.y, to.y, time),
 				z: V::ease(from.z, to.z, time),
-				w: V::ease(from.w, to.w, time)
+				w: V::ease(from.w, to.w, time),
 			}
 		}
 	}
@@ -134,7 +160,7 @@ mod mint_type_impls {
 		fn ease(from: Self, to: Self, time: impl Float) -> Self {
 			Self {
 				x: V::ease(from.x, to.x, time),
-				y: V::ease(from.y, to.y, time)
+				y: V::ease(from.y, to.y, time),
 			}
 		}
 	}
@@ -145,11 +171,8 @@ mod mint_type_impls {
 			Self {
 				x: V::ease(from.x, to.x, time),
 				y: V::ease(from.y, to.y, time),
-				z: V::ease(from.z, to.z, time)
+				z: V::ease(from.z, to.z, time),
 			}
 		}
 	}
 }
-
-#[cfg(feature = "mint_types")]
-pub use mint_type_impls::*;

--- a/src/easing.rs
+++ b/src/easing.rs
@@ -1,6 +1,9 @@
+use core::borrow::Borrow;
+
 pub(crate) use crate::*;
 
-use std::borrow::Borrow;
+#[cfg(feature = "mint_types")]
+pub use mint_type_impls::*;
 
 /// Implementation of a 2D curve function for easing between two points
 pub trait EasingFunction {

--- a/src/easing.rs
+++ b/src/easing.rs
@@ -43,9 +43,10 @@ impl CanTween for f64 {
 	}
 }
 
-impl<T: CanTween> CanTween for Vec<T> {
+#[cfg(feature = "alloc")]
+impl<T: CanTween> CanTween for alloc::vec::Vec<T> {
 	fn ease(from: Self, to: Self, time: impl Float) -> Self {
-		let mut new_vec = Vec::with_capacity(from.len());
+		let mut new_vec = alloc::vec::Vec::with_capacity(from.len());
 
 		let from_iterator = from.into_iter();
 		let to_iterator = to.into_iter();

--- a/src/functions/dynamic_functions.rs
+++ b/src/functions/dynamic_functions.rs
@@ -144,9 +144,20 @@ pub use bezier::*;
 pub struct Keyframes([f64; SAMPLE_TABLE_SIZE]);
 
 impl Keyframes {
-	pub(crate) fn from_easing_function<T: Float + CanTween + Copy>(mut s: AnimationSequence<T>) -> Self {
-		let mut low_point = s.sequence.get(0).and_then(|kf| kf.value().to_f64()).unwrap_or(0.0);
-		let mut high_point = s.sequence.get(s.keyframes() - 1).and_then(|kf| kf.value().to_f64()).unwrap_or(1.0);
+	#[cfg(feature = "alloc")]
+	pub(crate) fn from_easing_function<T: Float + CanTween + Copy>(
+		mut s: AnimationSequence<T>,
+	) -> Self {
+		let mut low_point = s
+			.sequence
+			.get(0)
+			.and_then(|kf| kf.value().to_f64())
+			.unwrap_or(0.0);
+		let mut high_point = s
+			.sequence
+			.get(s.keyframes() - 1)
+			.and_then(|kf| kf.value().to_f64())
+			.unwrap_or(1.0);
 		let max_time = s.duration();
 
 		if high_point == 0.0 || high_point == low_point {
@@ -157,7 +168,8 @@ impl Keyframes {
 		let mut sample_table = [0.0; SAMPLE_TABLE_SIZE];
 		for i in 0..SAMPLE_TABLE_SIZE {
 			s.advance_to((i as f64 / (SAMPLE_TABLE_SIZE - 1) as f64) * max_time);
-			sample_table[i] = (s.now_strict().and_then(|v| v.to_f64()).unwrap_or(0.5) - low_point) / (high_point - low_point);
+			sample_table[i] = (s.now_strict().and_then(|v| v.to_f64()).unwrap_or(0.5) - low_point)
+				/ (high_point - low_point);
 		}
 
 		Keyframes(sample_table)

--- a/src/functions/static_functions.rs
+++ b/src/functions/static_functions.rs
@@ -9,7 +9,9 @@ use crate::easing::*;
 pub struct Linear;
 impl EasingFunction for Linear {
 	#[inline]
-	fn y(&self, x: f64) -> f64 { x }
+	fn y(&self, x: f64) -> f64 {
+		x
+	}
 }
 
 /// Step function, returns the closest to either point A or B
@@ -18,7 +20,9 @@ impl EasingFunction for Linear {
 pub struct Step;
 impl EasingFunction for Step {
 	#[inline]
-	fn y(&self, x: f64) -> f64 { x.round() }
+	fn y(&self, x: f64) -> f64 {
+		x.round()
+	}
 }
 
 /// Accelerating quadratically from point A to point B
@@ -27,7 +31,9 @@ impl EasingFunction for Step {
 pub struct EaseInQuad;
 impl EasingFunction for EaseInQuad {
 	#[inline]
-	fn y(&self, x: f64) -> f64 { x * x }
+	fn y(&self, x: f64) -> f64 {
+		x * x
+	}
 }
 
 /// Decelerating quadratically from point A to point B
@@ -36,7 +42,9 @@ impl EasingFunction for EaseInQuad {
 pub struct EaseOutQuad;
 impl EasingFunction for EaseOutQuad {
 	#[inline]
-	fn y(&self, x: f64) -> f64 { x * (2.0 - x) }
+	fn y(&self, x: f64) -> f64 {
+		x * (2.0 - x)
+	}
 }
 
 /// Accelerating then decelerating quadratically from point A to point B
@@ -46,7 +54,11 @@ pub struct EaseInOutQuad;
 impl EasingFunction for EaseInOutQuad {
 	#[inline]
 	fn y(&self, x: f64) -> f64 {
-		if x < 0.5 { 2.0 * x * x } else { -1.0 + (4.0 - 2.0 * x) * x }
+		if x < 0.5 {
+			2.0 * x * x
+		} else {
+			-1.0 + (4.0 - 2.0 * x) * x
+		}
 	}
 }
 
@@ -56,7 +68,9 @@ impl EasingFunction for EaseInOutQuad {
 pub struct EaseInCubic;
 impl EasingFunction for EaseInCubic {
 	#[inline]
-	fn y(&self, x: f64) -> f64 { x * x * x }
+	fn y(&self, x: f64) -> f64 {
+		x * x * x
+	}
 }
 
 /// Decelerating cubically from point A to point B
@@ -78,8 +92,9 @@ pub struct EaseInOutCubic;
 impl EasingFunction for EaseInOutCubic {
 	#[inline]
 	fn y(&self, x: f64) -> f64 {
-		if x < 0.5 { 4.0 * x * x * x }
-		else {
+		if x < 0.5 {
+			4.0 * x * x * x
+		} else {
 			let x_minus_one = x - 1.0;
 			x_minus_one * (2.0 * x - 2.0) * (2.0 * x - 2.0) + 1.0
 		}
@@ -92,7 +107,9 @@ impl EasingFunction for EaseInOutCubic {
 pub struct EaseInQuart;
 impl EasingFunction for EaseInQuart {
 	#[inline]
-	fn y(&self, x: f64) -> f64 { x * x * x * x }
+	fn y(&self, x: f64) -> f64 {
+		x * x * x * x
+	}
 }
 
 /// Decelerating quartically from point A to point B
@@ -114,8 +131,9 @@ pub struct EaseInOutQuart;
 impl EasingFunction for EaseInOutQuart {
 	#[inline]
 	fn y(&self, x: f64) -> f64 {
-		if x < 0.5 { 8.0 * x * x * x * x }
-		else {
+		if x < 0.5 {
+			8.0 * x * x * x * x
+		} else {
 			let x_minus_one = x - 1.0;
 			1.0 - 8.0 * x_minus_one * x_minus_one * x_minus_one * x_minus_one
 		}
@@ -128,7 +146,9 @@ impl EasingFunction for EaseInOutQuart {
 pub struct EaseInQuint;
 impl EasingFunction for EaseInQuint {
 	#[inline]
-	fn y(&self, x: f64) -> f64 { x * x * x * x * x }
+	fn y(&self, x: f64) -> f64 {
+		x * x * x * x * x
+	}
 }
 
 /// Decelerating quintically from point A to point B
@@ -150,8 +170,9 @@ pub struct EaseInOutQuint;
 impl EasingFunction for EaseInOutQuint {
 	#[inline]
 	fn y(&self, x: f64) -> f64 {
-		if x < 0.5 { 16.0 * x * x * x * x * x }
-		else {
+		if x < 0.5 {
+			16.0 * x * x * x * x * x
+		} else {
 			let x_minus_one = x - 1.0;
 			1.0 + 16.0 * x_minus_one * x_minus_one * x_minus_one * x_minus_one * x_minus_one
 		}

--- a/src/functions/static_functions.rs
+++ b/src/functions/static_functions.rs
@@ -165,7 +165,7 @@ pub struct EaseIn;
 impl EasingFunction for EaseIn {
 	#[inline]
 	fn y(&self, x: f64) -> f64 {
-		((x - 1.0) * std::f64::consts::FRAC_PI_2).sin() + 1.0
+		((x - 1.0) * core::f64::consts::FRAC_PI_2).sin() + 1.0
 	}
 }
 
@@ -176,7 +176,7 @@ pub struct EaseOut;
 impl EasingFunction for EaseOut {
 	#[inline]
 	fn y(&self, x: f64) -> f64 {
-		(x * std::f64::consts::FRAC_PI_2).sin()
+		(x * core::f64::consts::FRAC_PI_2).sin()
 	}
 }
 
@@ -187,6 +187,6 @@ pub struct EaseInOut;
 impl EasingFunction for EaseInOut {
 	#[inline]
 	fn y(&self, x: f64) -> f64 {
-		0.5 * (1.0 - (x * std::f64::consts::PI).cos())
+		0.5 * (1.0 - (x * core::f64::consts::PI).cos())
 	}
 }

--- a/src/keyframe.rs
+++ b/src/keyframe.rs
@@ -1,0 +1,158 @@
+use alloc::{boxed::Box, fmt};
+use num_traits::Float;
+
+use crate::{
+	as_f64, ease_with_scaled_time,
+	easing::{EaseInOut, Linear},
+	CanTween, EasingFunction,
+};
+
+/// Intermediate step in an animation sequence
+pub struct Keyframe<T> {
+	value: T,
+	pub(crate) time: f64,
+	function: Box<dyn EasingFunction + Send + Sync>,
+}
+
+impl<T> Keyframe<T> {
+	/// Creates a new keyframe from the specified values.
+	/// If the time value is negative the keyframe will start at 0.0.
+	///
+	/// # Arguments
+	/// * `value` - The value that this keyframe will be tweened to/from
+	/// * `time` - The start time in seconds of this keyframe
+	/// * `function` - The easing function to use from the start of this keyframe to the start of the next keyframe
+	#[inline]
+	pub fn new<F: Float>(
+		value: T,
+		time: F,
+		function: impl EasingFunction + 'static + Send + Sync,
+	) -> Self {
+		Keyframe::<T> {
+			value: value,
+			time: if time < F::zero() { 0.0 } else { as_f64(time) },
+			function: Box::new(function),
+		}
+	}
+
+	/// Same as [`new`](#method.new), but allows you to supply an easing function which size is not known at compile time.
+	///
+	/// # Arguments
+	/// * `value` - The value that this keyframe will be tweened to/from
+	/// * `time` - The start time in seconds of this keyframe
+	/// * `function` - The easing function to use from the start of this keyframe to the start of the next keyframe
+	#[inline]
+	pub fn new_dynamic<F: Float>(
+		value: T,
+		time: F,
+		function: Box<dyn EasingFunction + 'static + Send + Sync>,
+	) -> Self {
+		Keyframe::<T> {
+			value: value,
+			time: if time < F::zero() { 0.0 } else { as_f64(time) },
+			function,
+		}
+	}
+
+	/// The value of this keyframe
+	#[inline]
+	pub fn value(&self) -> T
+	where
+		T: Copy,
+	{
+		self.value
+	}
+
+	/// The time in seconds at which this keyframe starts in a sequence
+	#[inline]
+	pub fn time(&self) -> f64 {
+		self.time
+	}
+
+	/// The easing function that will be used when tweening to another keyframe
+	#[inline]
+	pub fn function(&self) -> &dyn EasingFunction {
+		self.function.as_ref()
+	}
+
+	/// Returns the value between this keyframe and the next keyframe at the specified time
+	///
+	/// # Note
+	///
+	/// The following applies if:
+	/// * The requested time is before the start time of this keyframe: the value of this keyframe is returned
+	/// * The requested time is after the start time of next keyframe: the value of the next keyframe is returned
+	/// * The start time of the next keyframe is before the start time of this keyframe: the value of the next keyframe is returned
+	#[inline]
+	pub fn tween_to(&self, next: &Keyframe<T>, time: impl Float) -> T
+	where
+		T: CanTween + Copy,
+	{
+		match as_f64(time) {
+			// If the requested time starts before this keyframe
+			time if time < self.time => self.value,
+			// If the requested time starts after the next keyframe
+			time if time > next.time => next.value,
+			// If the next keyframe starts before this keyframe
+			_ if next.time < self.time => next.value,
+
+			time => T::ease(
+				self.value,
+				next.value,
+				self.function.y(ease_with_scaled_time(
+					Linear,
+					0.0,
+					1.0,
+					time - self.time,
+					next.time - self.time,
+				)),
+			),
+		}
+	}
+}
+
+impl<V, T: Float> From<(V, T)> for Keyframe<V> {
+	/// Creates a new keyframe from a tuple of (value, time).
+	/// `EaseInOut` will be used as the easing function.
+	/// If the time value is negative the keyframe will start at 0.0.
+	#[inline]
+	fn from(tuple: (V, T)) -> Self {
+		Keyframe::new(tuple.0, as_f64(tuple.1), EaseInOut)
+	}
+}
+
+impl<V, T: Float, F: EasingFunction + 'static + Send + Sync> From<(V, T, F)> for Keyframe<V> {
+	/// Creates a new keyframe from a tuple of (value, time, function).
+	/// If the time value is negative the keyframe will start at 0.0.
+	#[inline]
+	fn from(tuple: (V, T, F)) -> Self {
+		Keyframe::new(tuple.0, as_f64(tuple.1), tuple.2)
+	}
+}
+
+impl<V, T: Float> From<(V, T, Box<dyn EasingFunction + 'static + Send + Sync>)> for Keyframe<V> {
+	/// Creates a new keyframe from a tuple of (value, time, function).
+	/// If the time value is negative the keyframe will start at 0.0.
+	#[inline]
+	fn from(tuple: (V, T, Box<dyn EasingFunction + 'static + Send + Sync>)) -> Self {
+		Keyframe::new_dynamic(tuple.0, as_f64(tuple.1), tuple.2)
+	}
+}
+
+impl<T: fmt::Display> fmt::Display for Keyframe<T> {
+	#[inline]
+	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+		write!(f, "Keyframe at {:.2} s: {}", self.time, self.value)
+	}
+}
+
+impl<T: core::fmt::Debug> fmt::Debug for Keyframe<T> {
+	#[inline]
+	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+		write!(
+			f,
+			"Keyframe {{ value: {:?}, time: {:.2} }}",
+			self.value, self.time
+		)
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,13 +73,13 @@
 //! ```
 #![no_std]
 
-pub use num_traits;
 #[cfg(feature = "mint_types")]
 pub use mint;
+pub use num_traits;
 
-pub(crate) use num_traits::Float;
 #[cfg(feature = "mint_types")]
-pub(crate) use mint::{Vector2, Vector3, Vector4, Point2, Point3};
+pub(crate) use mint::{Point2, Point3, Vector2, Vector3, Vector4};
+pub(crate) use num_traits::Float;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,19 @@
 //! [`AnimationSequence`](struct.AnimationSequence.html) can be used to create more complex animations that keep track of keyframes, time, etc.
 //! You can create animation sequences with the [`keyframes![...]`](macro.keyframes.html) macro, from an iterator or from a vector.
 //!
+//! ## Embedded
+//!
+//! This library is embedded compatible. As default it uses the `alloc` crate for dynamic memory usage. So, if the `alloc` feature is turned off,
+//! by setting `default-features = false`, this `crate` can be used without dynamic memory usage. Keep in mind that this will disable the feature `mint_types`
+//! as well. This must be enabled by hand again.
+//!
+//! Disabled features:
+//! - [Keyframe]
+//! - [Sequence]
+//! - impl [CanTween] for [alloc::vec::Vec]
+//! - [Keyframes::from_easing_function()]
+//!
+//!
 //! ## Examples
 //!
 //! An example visualizer is included in `examples/`. Run `cargo run --example visualizer --release` to start it. (ggez is really slow in debug mode!)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,14 +81,23 @@ pub(crate) use num_traits::Float;
 #[cfg(feature = "mint_types")]
 pub(crate) use mint::{Vector2, Vector3, Vector4, Point2, Point3};
 
-use std::fmt;
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
-pub(crate) fn as_f64(value: impl Float) -> f64 { value.to_f64().expect(&format!("Value not representable in f64")) }
+pub(crate) fn as_f64(value: impl Float) -> f64 {
+	value.to_f64().expect("Value not representable in f64")
+}
 pub(crate) fn as_t<T: Float>(value: f64) -> T {
 	match value {
 		_ if value > as_f64(T::max_value()) => T::max_value(),
 		_ if value < as_f64(T::min_value()) => T::min_value(),
-		_ => T::from(value).expect(&format!("{} not representable in chosen float type", value))
+		#[cfg(feature = "alloc")]
+		_ => T::from(value).expect(&alloc::format!(
+			"{} not representable in chosen float type",
+			value
+		)),
+		#[cfg(not(feature = "alloc"))]
+		_ => T::from(value).expect("value not representable in chosen float type"),
 	}
 }
 
@@ -104,115 +113,12 @@ use functions::*;
 mod easing;
 pub use easing::*;
 
-/// Intermediate step in an animation sequence
-pub struct Keyframe<T> {
-	value: T,
-	time: f64,
-	function: Box<dyn EasingFunction + Send + Sync>
-}
+#[cfg(feature = "alloc")]
+mod keyframe;
+#[cfg(feature = "alloc")]
+pub use keyframe::*;
 
-impl<T> Keyframe<T> {
-	/// Creates a new keyframe from the specified values.
-	/// If the time value is negative the keyframe will start at 0.0.
-	///
-	/// # Arguments
-	/// * `value` - The value that this keyframe will be tweened to/from
-	/// * `time` - The start time in seconds of this keyframe
-	/// * `function` - The easing function to use from the start of this keyframe to the start of the next keyframe
-	#[inline]
-	pub fn new<F: Float>(value: T, time: F, function: impl EasingFunction + 'static + Send + Sync) -> Self {
-		Keyframe::<T> {
-			value: value,
-			time: if time < F::zero() { 0.0 } else { as_f64(time) },
-			function: Box::new(function)
-		}
-	}
-
-	/// Same as [`new`](#method.new), but allows you to supply an easing function which size is not known at compile time.
-	///
-	/// # Arguments
-	/// * `value` - The value that this keyframe will be tweened to/from
-	/// * `time` - The start time in seconds of this keyframe
-	/// * `function` - The easing function to use from the start of this keyframe to the start of the next keyframe
-	#[inline]
-	pub fn new_dynamic<F: Float>(value: T, time: F, function: Box<dyn EasingFunction + 'static + Send + Sync>) -> Self {
-		Keyframe::<T> {
-			value: value,
-			time: if time < F::zero() { 0.0 } else { as_f64(time) },
-			function
-		}
-	}
-
-	/// The value of this keyframe
-	#[inline]
-	pub fn value(&self) -> T where T: Copy { self.value }
-
-	/// The time in seconds at which this keyframe starts in a sequence
-	#[inline]
-	pub fn time(&self) -> f64 { self.time }
-
-	/// The easing function that will be used when tweening to another keyframe
-	#[inline]
-	pub fn function(&self) -> &dyn EasingFunction { self.function.as_ref() }
-
-	/// Returns the value between this keyframe and the next keyframe at the specified time
-	///
-	/// # Note
-	///
-	/// The following applies if:
-	/// * The requested time is before the start time of this keyframe: the value of this keyframe is returned
-	/// * The requested time is after the start time of next keyframe: the value of the next keyframe is returned
-	/// * The start time of the next keyframe is before the start time of this keyframe: the value of the next keyframe is returned
-	#[inline]
-	pub fn tween_to(&self, next: &Keyframe<T>, time: impl Float) -> T where T: CanTween + Copy {
-		match as_f64(time) {
-			// If the requested time starts before this keyframe
-			time if time < self.time => self.value,
-			// If the requested time starts after the next keyframe
-			time if time > next.time => next.value,
-			// If the next keyframe starts before this keyframe
-			_ if next.time < self.time => next.value,
-
-			time => T::ease(self.value, next.value, self.function.y(ease_with_scaled_time(Linear, 0.0, 1.0, time - self.time, next.time - self.time)))
-		}
-	}
-}
-
-impl<V, T: Float> From<(V, T)> for Keyframe<V> {
-	/// Creates a new keyframe from a tuple of (value, time).
-	/// `EaseInOut` will be used as the easing function.
-	/// If the time value is negative the keyframe will start at 0.0.
-	#[inline]
-	fn from(tuple: (V, T)) -> Self { Keyframe::new(tuple.0, as_f64(tuple.1), EaseInOut) }
-}
-
-impl<V, T: Float, F: EasingFunction + 'static + Send + Sync> From<(V, T, F)> for Keyframe<V> {
-	/// Creates a new keyframe from a tuple of (value, time, function).
-	/// If the time value is negative the keyframe will start at 0.0.
-	#[inline]
-	fn from(tuple: (V, T, F)) -> Self { Keyframe::new(tuple.0, as_f64(tuple.1), tuple.2) }
-}
-
-impl<V, T: Float> From<(V, T, Box<dyn EasingFunction + 'static + Send + Sync>)> for Keyframe<V> {
-	/// Creates a new keyframe from a tuple of (value, time, function).
-	/// If the time value is negative the keyframe will start at 0.0.
-	#[inline]
-	fn from(tuple: (V, T, Box<dyn EasingFunction + 'static + Send + Sync>)) -> Self { Keyframe::new_dynamic(tuple.0, as_f64(tuple.1), tuple.2) }
-}
-
-impl<T: fmt::Display> fmt::Display for Keyframe<T> {
-	#[inline]
-	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		write!(f, "Keyframe at {:.2} s: {}", self.time, self.value)
-	}
-}
-
-impl<T: fmt::Debug> fmt::Debug for Keyframe<T> {
-	#[inline]
-	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		write!(f, "Keyframe {{ value: {:?}, time: {:.2} }}", self.value, self.time)
-	}
-}
-
+#[cfg(feature = "alloc")]
 mod sequence;
+#[cfg(feature = "alloc")]
 pub use sequence::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
 //! #[derive(CanTween)]
 //! struct UnnamedStructure(MyStructure, f64);
 //! ```
+#![no_std]
 
 pub use num_traits;
 #[cfg(feature = "mint_types")]


### PR DESCRIPTION
Use `alloc` crate as dependency for dynamic memory. This allows to use the crate without std. As default, the feature `alloc` is enabled. This will enforce to use the crate as before. But it can be turned off to use it without the alloc stuff. Would allow using the easing functions in `no_std` environments.